### PR TITLE
0xc-convert: prefix argument as base.

### DIFF
--- a/0xc.el
+++ b/0xc.el
@@ -157,12 +157,12 @@ provided, additional sanity checks will be performed before converting"
     (- (aref (upcase digit) 0) 55)))
 
 ;;;###autoload
-(defun 0xc-convert (&optional number base silent)
+(defun 0xc-convert (base &optional number silent)
   "Read a number and a base, and output its representation in said base.
 If SILENT is non-nil, do not output anything"
-  (interactive)
+  (interactive "p")
   (let* ((number (or number (read-from-minibuffer "Number: ")))
-        (base (or base (read-minibuffer "Convert to base: ")))
+        (base (or (if (> base 1) base nil) (read-minibuffer "Convert to base: ")))
         (converted (0xc-number-to-string (0xc-string-to-number number) base)))
     (when (not silent) (message converted))
     converted))

--- a/test/0xc-test.el
+++ b/test/0xc-test.el
@@ -135,8 +135,8 @@
   (should (equal (0xc--strip-base-hint "1234567890:1") "1")))
 
 (ert-deftest 0xc-convert-test ()
-  (should (equal (0xc-convert "0xff" 10 t) "255"))
-  (should (equal (0xc-convert "0b1010" 10 t) "10"))
-  (should (equal (0xc-convert "7:100" 8 t) "61"))
-  (should (equal (0xc-convert "5:41300" 10 t) "2700"))
-  (should (equal (0xc-convert "0t10201020" 12 t) "1696")))
+  (should (equal (0xc-convert 10 "0xff" t) "255"))
+  (should (equal (0xc-convert 10 "0b1010" t) "10"))
+  (should (equal (0xc-convert 8 "7:100" t) "61"))
+  (should (equal (0xc-convert 10 "5:41300" t) "2700"))
+  (should (equal (0xc-convert 12 "0t10201020" t) "1696")))


### PR DESCRIPTION
This commit sets the given prefix argument as a base, prompting in the
minibuffer for a base only when needed.
## 

This is particularly useful for [`evil`](https://bitbucket.org/lyro/evil/wiki/Home) users such as myself.
