### PR TITLE
Add 'convert-point-to ()' routine

### DIFF
--- a/0xc.el
+++ b/0xc.el
@@ -88,6 +88,8 @@ length is a power of two"
   :group '0xc
   :type 'string)
 
+(defvar 0xc--recent-base 0)
+
 (defun 0xc-number-to-string (number base)
   "Convert an integer number into a different base string"
   (if (equal number 0) ""
@@ -196,6 +198,19 @@ to the user's preferences"
   "Return the smallest power of 2 greater than n"
   (expt 2 (ceiling (log n 2))))
 
+(defun pick-base (user-input-value default-value)
+  (if (= (length user-input-value) 0)
+      default-value
+    (string-to-number user-input-value)))
+
+(defun pick-base-and-store (default-value)
+  (if (= 0xc--recent-base 0)
+      (setq 0xc--recent-base default-value))
+  (setq 0xc--recent-base
+        (pick-base (read-string
+                    (format "Convert to base (default %d): " 0xc--recent-base))
+                   0xc--recent-base)))
+
 ;;;###autoload
 (defun 0xc-convert (base &optional number silent)
   "Read a number and a base, and output its representation in said base.
@@ -214,6 +229,20 @@ If SILENT is non-nil, do not output anything"
   (let ((bounds (bounds-of-thing-at-point 'word))
         (number (word-at-point)))
     (replace-regexp number (0xc-number-to-string (0xc-string-to-number number) (or base 0xc-default-base)) nil (car bounds) (cdr bounds))))
+
+;;;###autoload
+(defun 0xc-convert-point-to ()
+  "Replace the number at point with its representation to given base."
+  (interactive)
+  (let ((bounds (bounds-of-thing-at-point 'word))
+        (number (word-at-point)))
+    (replace-regexp
+     number
+     (0xc-number-to-string
+      (0xc-string-to-number number)
+      (pick-base-and-store 0xc-default-base))
+     nil (car bounds) (cdr bounds)))
+  )
 
 (provide '0xc)
 ;;; 0xc.el ends here


### PR DESCRIPTION
Interactive conversion with storing of recently selected base. Behavior like in "Query Replace". Function remember recently used conversion base value and repeat it if new user value is empty.

Maybe it can be useful for somebody.
